### PR TITLE
Fix broken link to WhatsApp in the iTunes store.

### DIFF
--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -28,7 +28,7 @@
             successCallback(@[]);
         } else {
           // Cannot open whatsapp
-          NSString *stringURL = @"http://itunes.apple.com/en/app/whatsapp-messenger/id310633997";
+          NSString *stringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
           NSURL *url = [NSURL URLWithString:stringURL];
           [[UIApplication sharedApplication] openURL:url];
 


### PR DESCRIPTION
The original link isn't resolving, so changed to a non-locale-specific iTunes URL.

While I was there, changed HTTP -> HTTPS.