### PR TITLE
Intent only got set once on instantiation.

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -77,6 +77,7 @@ public abstract class ShareIntent {
         Intent chooser = Intent.createChooser(this.getIntent(), this.chooserTitle);
         chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         this.reactContext.startActivity(chooser);
+        this.setIntent(null);
     }
     protected boolean isPackageInstalled(String packagename, Context context) {
         PackageManager pm = context.getPackageManager();
@@ -88,6 +89,9 @@ public abstract class ShareIntent {
         }
     }
     protected Intent getIntent(){
+        if (this.intent == null) {
+          this.setIntent(new Intent(android.content.Intent.ACTION_SEND));
+        }
         return this.intent;
     }
     protected void setIntent(Intent intent) {


### PR DESCRIPTION
If you're trying to attach multiple files (not at the same time) the second file you try to attach to an e-mail throws an error. This is because the Intent only gets set once upon instantiation. If you reset it at the end of the openIntentChooser function you can now attach other files without issue.