### PR TITLE
Fixed SLComposeViewController for iOS 11

### DIFF
--- a/ios/GenericShare.h
+++ b/ios/GenericShare.h
@@ -50,6 +50,6 @@
 #import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
 #endif
 @interface GenericShare : NSObject <RCTBridgeModule>
-
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType;
-@end
+    
+- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType shouldOpenInWeb: (BOOL) openInWeb;
+    @end

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -12,13 +12,14 @@
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
     successCallback:(RCTResponseSenderBlock)successCallback
-    serviceType:(NSString*)serviceType {
-
+        serviceType:(NSString*)serviceType shouldOpenInWeb:(BOOL) openInWeb {
+    
     NSLog(@"Try open view");
-    if([SLComposeViewController isAvailableForServiceType:serviceType]) {
-
+    //    [SLComposeViewController isAvailableForServiceType:serviceType]
+    if(!openInWeb ) {
+        
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
-
+        
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];
         if (URL) {
             if (URL.fileURL || [URL.scheme.lowercaseString isEqualToString:@"data"]) {
@@ -32,52 +33,55 @@
                 }
                 UIImage *image = [UIImage imageWithData: data];
                 [composeController addImage:image];
-
+                
             } else {
                 [composeController addURL:URL];
             }
         }
-
+        
         if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
             NSString *text = [RCTConvert NSString:options[@"message"]];
             [composeController setInitialText:text];
         }
-
-
+        
+        
         UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
         [ctrl presentViewController:composeController animated:YES completion:Nil];
         successCallback(@[]);
-      } else {
+        return;
+    } else {
         NSString *errorMessage = @"Not installed";
         NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
         NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
+        
         NSLog(errorMessage);
         failureCallback(error);
-
+        
         NSString *escapedString = [options[@"message"] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-
+        
         if ([options[@"social"] isEqualToString:@"twitter"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://twitter.com/intent/tweet?message=%@&url=%@", escapedString, options[@"url"]];
-          [self openScheme:URL];
+            NSString *URL = [NSString stringWithFormat:@"https://twitter.com/intent/tweet?message=%@&url=%@", escapedString, options[@"url"]];
+            [self openScheme:URL];
         }
-
+        
         if ([options[@"social"] isEqualToString:@"facebook"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://www.facebook.com/sharer/sharer.php?u=%@", options[@"url"]];
-          [self openScheme:URL];
+            NSString *URL = [NSString stringWithFormat:@"https://www.facebook.com/sharer/sharer.php?u=%@", options[@"url"]];
+            [self openScheme:URL];
         }
+        
+    }
+}
 
-      }
-  }
-  - (void)openScheme:(NSString *)scheme {
-      UIApplication *application = [UIApplication sharedApplication];
-      NSURL *schemeURL = [NSURL URLWithString:scheme];
+- (void)openScheme:(NSString *)scheme {
+        UIApplication *application = [UIApplication sharedApplication];
+        NSURL *schemeURL = [NSURL URLWithString:scheme];
+        
+        if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+            [application openURL:schemeURL options:@{} completionHandler:nil];
+            NSLog(@"Open %@: %d", schemeURL);
+        }
+        
+}
+    
+@end
 
-      if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
-          [application openURL:schemeURL options:@{} completionHandler:nil];
-          NSLog(@"Open %@: %d", schemeURL);
-      }
-
-  }
-
-  @end

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -47,45 +47,47 @@
 
 @implementation RNShare
 - (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
-}
-RCT_EXPORT_MODULE()
-
-RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
-                  failureCallback:(RCTResponseErrorBlock)failureCallback
-                  successCallback:(RCTResponseSenderBlock)successCallback)
-{
-    
-    NSString *social = [RCTConvert NSString:options[@"social"]];
-    if (social) {
-        NSLog(social);
-        if([social isEqualToString:@"facebook"]) {
-            NSLog(@"TRY OPEN FACEBOOK");
-            GenericShare *shareCtl = [[GenericShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeFacebook];
-        } else if([social isEqualToString:@"twitter"]) {
-            NSLog(@"TRY OPEN Twitter");
-            GenericShare *shareCtl = [[GenericShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeTwitter];
-        } else if([social isEqualToString:@"googleplus"]) {
-            NSLog(@"TRY OPEN google plus");
-            GooglePlusShare *shareCtl = [[GooglePlusShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
-        } else if([social isEqualToString:@"whatsapp"]) {
-            NSLog(@"TRY OPEN whatsapp");
-            
-            WhatsAppShare *shareCtl = [[WhatsAppShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
-        } else if([social isEqualToString:@"email"]) {
-            NSLog(@"TRY OPEN email");
-            EmailShare *shareCtl = [[EmailShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
-        }
-    } else {
-        RCTLogError(@"key 'social' missing in options");
-        return;
+    {
+        return dispatch_get_main_queue();
     }
-}
+    RCT_EXPORT_MODULE()
+    
+    RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
+                      failureCallback:(RCTResponseErrorBlock)failureCallback
+                      successCallback:(RCTResponseSenderBlock)successCallback)
+    {
+        
+        NSString *social = [RCTConvert NSString:options[@"social"]];
+        BOOL openInWeb = [RCTConvert BOOL:options[@"openInWeb"]] ?: NO;
+        if (social) {
+            NSLog(social);
+            if([social isEqualToString:@"facebook"]) {
+                NSLog(@"TRY OPEN FACEBOOK");
+                GenericShare *shareCtl = [[GenericShare alloc] init];
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeFacebook shouldOpenInWeb:openInWeb];
+            } else if([social isEqualToString:@"twitter"]) {
+                NSLog(@"TRY OPEN Twitter");
+                GenericShare *shareCtl = [[GenericShare alloc] init];
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeTwitter shouldOpenInWeb:openInWeb];
+            } else if([social isEqualToString:@"googleplus"]) {
+                NSLog(@"TRY OPEN google plus");
+                GooglePlusShare *shareCtl = [[GooglePlusShare alloc] init];
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            } else if([social isEqualToString:@"whatsapp"]) {
+                NSLog(@"TRY OPEN whatsapp");
+                
+                WhatsAppShare *shareCtl = [[WhatsAppShare alloc] init];
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            } else if([social isEqualToString:@"email"]) {
+                NSLog(@"TRY OPEN email");
+                EmailShare *shareCtl = [[EmailShare alloc] init];
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            }
+        } else {
+            RCTLogError(@"No exists social key");
+            return;
+        }
+    }
+    
+    @end
 
-@end


### PR DESCRIPTION
SLComposeViewController.isAvailableForServiceType is unneeded and always returns false, iOS handles these errors (case no facebook/twitter user is available.
this is true for older iOS versions as well, tested on 9,9.3,10.3.1 and 11.
once trying to load the SLComposeViewController, if no social account is present, the user will simply get a message around the lines of "No facebook/twitter account is configured, this can be done from the settings".
SLComposeViewController.isAvailableForServiceType is always returning false and I needed the share to open the facebook/twitter popup inside the app, this works without the isAvailableForServiceType.

I expanded the method GenericShare.singleShare to include shouldOpenInWeb flag, just in case someone wants to open the share in the browser.
