### PR TITLE
Update README.md to better specify manual Android installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Share Social , Sending Simple Data to Other Apps
     ```
       compile project(':react-native-share')
     ```
-5. Follow this [guide](https://developer.android.com/training/secure-file-sharing/setup-sharing.html)
-Example:
+5. [Follow this guide (do not forget your provider `meta-data` tag and to create your `filepaths.xml` file)](https://developer.android.com/training/secure-file-sharing/setup-sharing.html). As an example:
 Put this in `AndroidManifest.xml` where `applicationId` is something that you have defined in `android/app/build.gradle`.
     ```xml
       <application>
@@ -58,6 +57,7 @@ Put this in `AndroidManifest.xml` where `applicationId` is something that you ha
         </provider>
       </application>
     ```
+ 
 6. Make your `Application` class implements `ShareApplication`
   - Make `getFileProviderAuthority` function return the `android:authorities` that was added on AndroidManifest file
   - Example: `applicationId` is defined in `android/app/build.gradle`.


### PR DESCRIPTION
Added additional information to the Android manual installation in the README based on my own experience since I miss read the guide link in step 5 and was getting all kind of weird errors.

I think it might help other people to have it a little more large and clear.

Either way if you decide to merge this or not thank you for the awesome work with the library.