### PR TITLE
updating README - adding android permission request section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Share Social , Sending Simple Data to Other Apps
 
     }
     ```
+7. When using targetSdkVersion 23 or greater, you might need to explicitly ask for permission otherwise sharing a base64 image will fail : 
+  ```
+  const allowedStorage = await PermissionsAndroid.request(
+    PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
+  );
+  ```
 
 
 #### Windows


### PR DESCRIPTION
Sharing base64 image fails on android API 23 and higher if permissions has not been requested.
This seems to affect a number of user : 

- https://github.com/react-native-community/react-native-share/issues/142
- https://github.com/react-native-community/react-native-share/issues/236
- https://github.com/react-native-community/react-native-share/issues/233
- https://github.com/react-native-community/react-native-share/issues/184

I added a step in the android installation step by step, hoping that it will save others some time :)