### PR TITLE
Allow specifying reject/resolve for user cancel action for sharing on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Supported options:
 | title | string   |  (optional) |
 | subject | string   | (optional) |
 | excludedActivityTypes | string   | (optional) |
-| failOnCancel | boolean | (defaults to true) on iOS, specifies whether promise should reject if user cancels share dialog (optional) |
+| failOnCancel | boolean | (defaults to true) On iOS, specifies whether promise should reject if user cancels share dialog (optional) |
 
 #### shareSingle(options) (in iOS & Android)
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Supported options:
 | excludedActivityTypes | string   | (optional) |
 | failOnCancel | boolean | (defaults to true) On iOS, specifies whether promise should reject if user cancels share dialog (optional) |
 | showAppsToView | boolean | (optional) only android|
->>>>>>> upstream/master
 
 #### shareSingle(options) (in iOS & Android)
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Supported options:
 | title | string   |  (optional) |
 | subject | string   | (optional) |
 | excludedActivityTypes | string   | (optional) |
+| failOnCancel | boolean | (defaults to true) on iOS, specifies whether promise should reject if user cancels share dialog (optional) |
 
 #### shareSingle(options) (in iOS & Android)
 

--- a/index.js
+++ b/index.js
@@ -37,9 +37,13 @@ class RNShare {
         ActionSheetIOS.showShareActionSheetWithOptions(options, (error) => {
           return reject({ error: error });
         }, (success, activityType) => {
-          if(success) {
+          if (success) {
             return resolve({
               app: activityType
+            });
+          } else if (options.failOnCancel === false) {
+            return resolve({
+              dismissedAction: true,
             });
           } else {
             reject({ error: "User did not share" });


### PR DESCRIPTION
New optional param for `Share.open` method to cause promise to resolve on user cancel action, rather than rejecting.

This only affects iOS. On android this module already does not reject if user cancels, although there appear to be a couple of requests for supporting that functionality.

Resolves #245 