### PR TITLE
Permission handling for android in case of base64 sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,6 @@ Share Social , Sending Simple Data to Other Apps
 
     }
     ```
-7. When using targetSdkVersion 23 or greater, you might need to explicitly ask for permission otherwise sharing a base64 image will fail :
-  ```
-  const allowedStorage = await PermissionsAndroid.request(
-    PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
-  );
-  ```
   
 #### Windows Install
     

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,7 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
+    jcenter()
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,52 +1,56 @@
 buildscript {
-  repositories {
-    jcenter()
-    maven {
-      url 'https://maven.google.com/'
-      name 'Google'
+    repositories {
+        jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
-  }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:+'
+    }
 }
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 26
-def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.2"
-def DEFAULT_TARGET_SDK_VERSION              = 26
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "12.0.1"
-def DEFAULT_SUPPORT_LIBRARY_VERSION         = "27.1.0"
+def DEFAULT_COMPILE_SDK_VERSION = 26
+def DEFAULT_BUILD_TOOLS_VERSION = "26.0.2"
+def DEFAULT_TARGET_SDK_VERSION = 26
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION = "12.0.1"
+def DEFAULT_SUPPORT_LIBRARY_VERSION = "27.1.0"
 
 android {
-  compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
-  defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
 
-    versionCode 1
-    versionName "1.0.0"
-  }
-  lintOptions {
-    abortOnError false
-    warning 'InvalidPackage'
-  }
+        versionCode 1
+        versionName "1.0.0"
+    }
+    lintOptions {
+        abortOnError false
+        warning 'InvalidPackage'
+    }
 }
 
 repositories {
-  mavenCentral()
-  maven {
-   url 'https://maven.google.com/'
-   name 'Google'
-  }
-  maven {
-    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-    url "$rootDir/../node_modules/react-native/android"
-  }
+    mavenCentral()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+    }
 }
 
 dependencies {
-    def supportLibVersion = rootProject.hasProperty('supportLibVersion')  ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIBRARY_VERSION
+    def supportLibVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIBRARY_VERSION
 
     compile 'com.facebook.react:react-native:+'
     compile "com.android.support:appcompat-v7:$supportLibVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,10 +6,6 @@ buildscript {
       name 'Google'
     }
   }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
-  }
 }
 
 apply plugin: 'com.android.library'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
   repositories {
     jcenter()
-    google()
     maven {
-      url 'https://maven.google.com'
+      url 'https://maven.google.com/'
+      name 'Google'
     }
   }
 
@@ -40,7 +40,8 @@ android {
 repositories {
   mavenCentral()
   maven {
-   url 'https://maven.google.com'
+   url 'https://maven.google.com/'
+   name 'Google'
   }
   maven {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -51,6 +52,6 @@ repositories {
 dependencies {
     def supportLibVersion = rootProject.hasProperty('supportLibVersion')  ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIBRARY_VERSION
 
-    compileOnly 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
     compile "com.android.support:appcompat-v7:$supportLibVersion"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-# Sun Dec 31 13:43:56 BRST 2017
+#Fri Jun 29 16:58:39 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="cl.json">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 
 import cl.json.social.EmailShare;
 import cl.json.social.FacebookShare;
-import cl.json.social.FacebookPagesManagerShare;
 import cl.json.social.GenericShare;
 import cl.json.social.GooglePlusShare;
 import cl.json.social.ShareIntent;
@@ -33,7 +32,6 @@ public class RNShareModule extends ReactContextBaseJavaModule {
         this.reactContext = reactContext;
         sharesExtra.put("generic", new GenericShare(this.reactContext));
         sharesExtra.put("facebook", new FacebookShare(this.reactContext));
-        sharesExtra.put("pagesmanager", new FacebookPagesManagerShare(this.reactContext));
         sharesExtra.put("twitter", new TwitterShare(this.reactContext));
         sharesExtra.put("whatsapp",new WhatsAppShare(this.reactContext));
         sharesExtra.put("instagram",new InstagramShare(this.reactContext));
@@ -57,6 +55,10 @@ public class RNShareModule extends ReactContextBaseJavaModule {
             System.out.println("ERROR");
             System.out.println(ex.getMessage());
             failureCallback.invoke("not_available");
+        }catch (Exception e) {
+            System.out.println("ERROR");
+            System.out.println(e.getMessage());
+            failureCallback.invoke(e.getMessage());
         }
     }
     @ReactMethod
@@ -70,9 +72,30 @@ public class RNShareModule extends ReactContextBaseJavaModule {
                 System.out.println("ERROR");
                 System.out.println(ex.getMessage());
                 failureCallback.invoke(ex.getMessage());
+            }catch (Exception e) {
+                System.out.println("ERROR");
+                System.out.println(e.getMessage());
+                failureCallback.invoke(e.getMessage());
             }
         } else {
             failureCallback.invoke("key 'social' missing in options");
+        }
+    }
+
+    @ReactMethod
+    public void isBase64File(String url, @Nullable Callback failureCallback, @Nullable Callback successCallback) {
+        try {
+            Uri uri = Uri.parse(url);
+            String scheme = uri.getScheme();
+            if((scheme != null) && scheme.equals("data")) {
+                successCallback.invoke(true);
+            } else {
+                successCallback.invoke(false);
+            }
+        } catch (Exception e) {
+            System.out.println("ERROR");
+            System.out.println(e.getMessage());
+            failureCallback.invoke(e.getMessage());
         }
     }
 }

--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 
 import cl.json.social.EmailShare;
 import cl.json.social.FacebookShare;
+import cl.json.social.FacebookPagesManagerShare;
 import cl.json.social.GenericShare;
 import cl.json.social.GooglePlusShare;
 import cl.json.social.ShareIntent;
@@ -32,6 +33,7 @@ public class RNShareModule extends ReactContextBaseJavaModule {
         this.reactContext = reactContext;
         sharesExtra.put("generic", new GenericShare(this.reactContext));
         sharesExtra.put("facebook", new FacebookShare(this.reactContext));
+        sharesExtra.put("pagesmanager", new FacebookPagesManagerShare(this.reactContext));
         sharesExtra.put("twitter", new TwitterShare(this.reactContext));
         sharesExtra.put("whatsapp",new WhatsAppShare(this.reactContext));
         sharesExtra.put("instagram",new InstagramShare(this.reactContext));

--- a/index.js
+++ b/index.js
@@ -32,6 +32,45 @@ const styles = StyleSheet.create({
   },
 });
 
+type Props = {
+  visible: boolean,
+  onCancel: () => void,
+  children: React.Node,
+};
+
+class ShareSheet extends React.Component<Props> {
+  backButtonHandler: () => boolean;
+
+  componentDidMount() {
+    this.backButtonHandler = this.backButtonHandler.bind(this);
+    BackHandler.addEventListener('backPress', this.backButtonHandler);
+  }
+
+  componentWillUnmount() {
+    BackHandler.removeEventListener('backPress', this.backButtonHandler);
+  }
+
+  backButtonHandler() {
+    if (this.props.visible) {
+      this.props.onCancel();
+      return true;
+    }
+    return false;
+  }
+  render() {
+    return (
+      <Overlay visible={this.props.visible} {...this.props}>
+        <View style={styles.actionSheetContainer}>
+          <TouchableOpacity style={{ flex: 1 }} onPress={this.props.onCancel} />
+          <Sheet visible={this.props.visible}>
+            <View style={styles.buttonContainer}>{this.props.children}</View>
+          </Sheet>
+        </View>
+      </Overlay>
+    );
+  }
+}
+
 type Options = {
   url: string,
   urls: Array<string>,
@@ -55,11 +94,11 @@ const requireAndAskPermissions = (options: Options): Promise<any> => {
           return new Promise((res, rej) => {
             NativeModules.RNShare.isBase64File(
               url,
-              isBase64 => {
-                res(isBase64);
-              },
               e => {
                 rej(e);
+              },
+              isBase64 => {
+                res(isBase64);
               },
             );
           });
@@ -82,7 +121,7 @@ const requireAndAskPermissions = (options: Options): Promise<any> => {
           if (result === PermissionsAndroid.RESULTS.GRANTED) {
             return resolve();
           }
-          return Promise.reject(new Error('Permission Denied'));
+          return Promise.reject(new Error('Write Permission not available'));
         })
         .catch(e => reject(e));
     });
@@ -180,50 +219,10 @@ class RNShare {
       throw new Error('Not implemented');
     }
   }
-
-  static ShareSheet = ShareSheet;
-  static Button = Button;
-  static Sheet = Sheet;
-  static Overlay = Overlay;
-}
-
-type Props = {
-  visible: boolean,
-  onCancel: () => void,
-  children: React.Node,
-};
-
-class ShareSheet extends React.Component<Props> {
-  backButtonHandler: Function;
-
-  componentDidMount() {
-    this.backButtonHandler = this.backButtonHandler.bind(this);
-    BackHandler.addEventListener('backPress', this.backButtonHandler);
-  }
-
-  componentWillUnmount() {
-    BackHandler.removeEventListener('backPress', this.backButtonHandler);
-  }
-
-  backButtonHandler() {
-    if (this.props.visible) {
-      this.props.onCancel();
-      return true;
-    }
-    return false;
-  }
-  render() {
-    return (
-      <Overlay visible={this.props.visible} {...this.props}>
-        <View style={styles.actionSheetContainer}>
-          <TouchableOpacity style={{ flex: 1 }} onPress={this.props.onCancel} />
-          <Sheet visible={this.props.visible}>
-            <View style={styles.buttonContainer}>{this.props.children}</View>
-          </Sheet>
-        </View>
-      </Overlay>
-    );
-  }
 }
 
 module.exports = RNShare;
+module.exports.ShareSheet = ShareSheet;
+module.exports.Button = Button;
+module.exports.Sheet = Sheet;
+module.exports.Overlay = Overlay;

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ class RNShare {
 }
 
 module.exports = RNShare;
-module.exports.ShareSheet = ShareSheet;
-module.exports.Button = Button;
-module.exports.Sheet = Sheet;
 module.exports.Overlay = Overlay;
+module.exports.Sheet = Sheet;
+module.exports.Button = Button;
+module.exports.ShareSheet = ShareSheet;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-react": "^7.6.1",
     "eslint-plugin-react-native": "^3.2.0",
+    "flow-bin": "^0.69.0",
     "generate-changelog": "1.7.0",
     "husky": "^0.14.3",
     "minimist": "1.2.0",


### PR DESCRIPTION
Handling of android permissions in case of sdk version greater than 22. It is handled by checking if the sharing options contains url(s) and if they do and they are base64 strings, then check for write storage permission and proceed accordingly. If the permission is denied, then the share is rejected with 'Permission denied' error.  

Also gradle tools version is made generic to tackle errors in projects using gradle version lesser than this library.