### PR TITLE
Fixing Possible Error during build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '27.1.0')}"
+    provided "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    compile "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '27.1.0')}"
 }


### PR DESCRIPTION
I encountered build error using react-native@0.56.0

Error Message:
```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/richardng/Projects/whoisspy/node_modules/react-native-share/android/build.gradle' line: 53

* What went wrong:
A problem occurred evaluating project ':react-native-share'.
> Could not find method compileOnly() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```
Enable to solve by:
compileOnly -> provided
implementation -> compile
in the dependencies section of build.gradle