### PR TITLE
[README] Add import to MainApplication.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Share Social , Sending Simple Data to Other Apps
 
 1. `npm install react-native-share --save`
 2. Open up `android/app/src/main/java/[...]/MainApplication.java`
-  - Add `import cl.json.RNSharePackage;` to the imports at the top of the file
+  - Add `import cl.json.RNSharePackage;` and `import cl.json.ShareApplication;` to the imports at the top of the file
   - Add `new RNSharePackage()` to the list returned by the `getPackages()`
     method
 3. Append the following lines to `android/settings.gradle`:


### PR DESCRIPTION
Failed to build for android when following the README.

Error Message:
```
:app:compileDebugJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
/Users/richardng/Projects/whoisspy/android/app/src/main/java/com/whoisspy/MainApplication.java:17: error: cannot find symbol
public class MainApplication extends Application implements ReactApplication, ShareApplication {
                                                                              ^
  symbol: class ShareApplication
/Users/richardng/Projects/whoisspy/android/app/src/main/java/com/whoisspy/MainApplication.java:19: error: method does not override or implement a method from a supertype
  @Override
  ^
2 errors
:app:compileDebugJavaWithJavac FAILED
```

Able to solve by:
Add `import cl.json.RNSharePackage;` and `import cl.json.ShareApplication;` to the imports of MainApplication.java