### PR TITLE
build: reverse dep order, google then jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -33,7 +33,6 @@ android {
 }
 
 repositories {
-    mavenCentral()
     google()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
Fixes #386 where jcenter had a POM but 404d the artifact, breaking builds,
while google has the POM and artifact (as it's a google support library)

Also, jcenter is a superset of mavenCentral, so mavenCentral is
redundant:
https://jfrog.com/knowledge-base/why-should-i-use-jcenter-over-maven-central/