### PR TITLE
Fix flow types for ShareSheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ const requireAndAskPermissions = async (options: Options | MultipleOptions): Pro
 
 class RNShare {
   static Button: any;
-  static ShareSheet: React.createElement;
+  static ShareSheet: React.Element<*>;
   static Overlay: any;
   static Sheet: any;
   static Social = {


### PR DESCRIPTION
Currently, flow `0.85.0` gives the following error while using the library:

![image](https://user-images.githubusercontent.com/9068073/51936852-2f21ba80-241a-11e9-9e7b-3c07c5f96fc3.png)

And it's not possible to use flow without ignoring this library in configs. My PR fixes this issue.