### PR TITLE
SingleShare forceDialog option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Supported options:
 | title | string   |  (optional) |
 | subject | string   | (optional) |
 | social | string   | supported social apps: [List](#static-values-for-social)  |
+| forceDialog | boolean | (optional) only android. Avoid showing dialog with buttons Just Once / Always. Useful for Instagram to always ask user if share as Story or Feed |
 
 ***NOTE: If both `message` and `url` are provided `url` will be concatenated to the end of `message` to form the body of the message. If only one is provided it will be used***
 

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -55,7 +55,13 @@ public abstract class SingleShareIntent extends ShareIntent {
         super.open(options);
     }
     protected void openIntentChooser() throws ActivityNotFoundException {
-        this.getIntent().setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        this.reactContext.startActivity(this.getIntent());
+        if(this.options.hasKey("forceDialog") && this.options.getBoolean("forceDialog")){
+             Intent chooser = Intent.createChooser(this.getIntent(), this.chooserTitle);
+             chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+             this.reactContext.startActivity(chooser);
+        }else{
+             this.getIntent().setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+             this.reactContext.startActivity(this.getIntent());
+        }
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -32,3 +32,4 @@ jobs:
           key: v1_1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
+

--- a/circle.yml
+++ b/circle.yml
@@ -3,19 +3,15 @@ executorType: docker
 jobs:
   build:
     resource_class: large
-    environment:
-      - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-      - REACT_NATIVE_MAX_WORKERS: 2
-      - ANDROID_BUILD_TOOLS_VERSION: "27.0.2"
     working_directory: ~/app
     docker:
-      - image: entria/react-native-android:0.1.72
+      - image: circleci/android:api-28-node
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - v1-npm
+            - v1_1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - v1_1-npm
       - run:
           name: Install Dependencies
           command: yarn install
@@ -29,10 +25,10 @@ jobs:
             chmod +x ./gradlew
             ./gradlew clean && ./gradlew && ./gradlew check
       - save_cache:
-          key: v1-npm
+          key: v1_1-npm
           paths:
             - node_modules/
       - save_cache:
-          key: v1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: v1_1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/


### PR DESCRIPTION
This pull request resolves Android workflow issue with some social medias singleShare.

### The way it works now 
User share an image to instagram and see this 
![img_0350](https://user-images.githubusercontent.com/2223591/51980876-a181b180-2491-11e9-8615-4a82e4670f2e.JPG)
### Problem
1. user clicks Always and share to Instagram Feed
2. User shares again, and the app opens Instagram Feed by default 

User is not being able to share to Instagram Story anymore, as Android remember decision.

### Proposed solution 
On Android I suggest option **forceDialog**, which disables buttons Always / Just once. Instead, it always forces to choose the option. It looks as attached below.

![img_8474](https://user-images.githubusercontent.com/2223591/51981000-f7eef000-2491-11e9-8912-8d3d15ae18e8.JPG)

