### PR TITLE
fix android sms share default app issue

### DIFF
--- a/android/src/main/java/cl/json/social/SMSShare.java
+++ b/android/src/main/java/cl/json/social/SMSShare.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import java.io.File;
 import android.os.Environment;
 import android.net.Uri;
+import android.provider.Telephony;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -16,9 +17,12 @@ public class SMSShare extends SingleShareIntent {
 
     private static final String PACKAGE = "com.android.mms";
     private static final String PLAY_STORE_LINK = "market://details?id=com.android.mms";
+
+    private ReactApplicationContext reactContext = null;
     
     public SMSShare(ReactApplicationContext reactContext) {
         super(reactContext);
+        this.reactContext = reactContext;
     }
 
     @Override
@@ -30,6 +34,9 @@ public class SMSShare extends SingleShareIntent {
 
     @Override
     protected String getPackage() {
+        if (android.os.Build.VERSION.SDK_INT >= 19 ) {
+            return Telephony.Sms.getDefaultSmsPackage(this.reactContext);
+        }
         return PACKAGE;
     }
 


### PR DESCRIPTION
# Overview
In my Android phone, the sms share is not functional.
So I use `android.provider.Telephony.Sms.getDefaultSmsPackage` to get system provider package name.

# Test Plan
when android use `Share.shareSingle` with sms, will correctly work.  ( call to internal sms app ).
