### PR TITLE
Adding stale config to handle stale issues following react-native as …

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,46 @@
+# Configuration for probot-stale based on: https://github.com/facebook/react-native/blob/master/.github/stale.yml
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - discussion
+  - good first issue
+  - good first issue
+  - "help wanted"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions. You may also mark this issue as a "discussion" and i
+  will leave this open.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Closing this issue after a prolonged period of inactivity. Fell free to reopen
+  this issue, if this still affecting you.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
# Overview
As I had discussed with @jgcmarins  at one time, it would be interesting to start using an IC, or something like that to deal with some parts of the project.

An interesting alternative was the pro-bot since it has a simple configuration and is used in several projects in the community, and is used by react-native as it can be seen here: https://github.com/facebook/react-native/blob/master/.github/stale.yml

Before opening this pr, I included some labels based on react-native like: stale, discussion, etc. I choose to set the pro-bot to watch issues, and leave PR opened.

Also, I need the help of someone on the core of react-native-community to approve the pro-bot app request. 

Btw, i hope this help the project maintainers to focus on important features. :smiley: 
