### PR TITLE
Facebook, Twitter and Instagram shareSingle - Fix on iOS 11

### DIFF
--- a/ios/GenericShare.h
+++ b/ios/GenericShare.h
@@ -52,4 +52,5 @@
 @interface GenericShare : NSObject <RCTBridgeModule>
 
 - (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType;
+    inAppBaseUrl:(NSString *)inAppBaseUrl;
 @end

--- a/ios/GenericShare.h
+++ b/ios/GenericShare.h
@@ -51,6 +51,6 @@
 #endif
 @interface GenericShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType;
+- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType
     inAppBaseUrl:(NSString *)inAppBaseUrl;
 @end

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -13,10 +13,11 @@
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
     successCallback:(RCTResponseSenderBlock)successCallback
-    serviceType:(NSString*)serviceType {
+    serviceType:(NSString*)serviceType
+    inAppBaseUrl:(NSString *)inAppBaseUrl {
 
     NSLog(@"Try open view");
-    if([SLComposeViewController isAvailableForServiceType:serviceType]) {
+    if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
 
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
 
@@ -45,7 +46,7 @@
         }
 
 
-        UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        UIViewController *ctrl = RCTPresentedViewController();
         [ctrl presentViewController:composeController animated:YES completion:Nil];
         successCallback(@[]);
       } else {

--- a/ios/InstagramShare.h
+++ b/ios/InstagramShare.h
@@ -49,4 +49,7 @@
 @interface InstagramShare : NSObject <RCTBridgeModule>
 
 - (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void)shareSingleImage:(NSDictionary *)options
+         failureCallback:(RCTResponseErrorBlock)failureCallback
+         successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -7,6 +7,7 @@
 
 #import "InstagramShare.h"
 #import <AVFoundation/AVFoundation.h>
+@import Photos;
 
 @implementation InstagramShare
     RCT_EXPORT_MODULE();

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -50,4 +50,74 @@
     } 
 }
 
+- (void)shareSingleImage:(NSDictionary *)options
+         failureCallback:(RCTResponseErrorBlock)failureCallback
+         successCallback:(RCTResponseSenderBlock)successCallback {
+    
+    UIImage *image;
+    NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
+    if (imageURL) {
+        if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
+            NSError *error;
+            NSData *data = [NSData dataWithContentsOfURL:imageURL
+                                                 options:(NSDataReadingOptions)0
+                                                   error:&error];
+            if (!data) {
+                failureCallback(error);
+                return;
+            }
+            image = [UIImage imageWithData: data];
+            [self savePictureAndOpenInstagram: image
+                              failureCallback: failureCallback
+                              successCallback: successCallback];
+        }
+    } else {
+        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"]];
+        successCallback(@[]);
+    }
+}
+
+-(void)savePictureAndOpenInstagram:(UIImage *)base64Image
+                   failureCallback:(RCTResponseErrorBlock)failureCallback
+                   successCallback:(RCTResponseSenderBlock)successCallback {
+    
+    NSURL *URL = [self fileURLWithTemporaryImageData:UIImageJPEGRepresentation(base64Image, 0.9)];
+    __block PHAssetChangeRequest *_mChangeRequest = nil;
+    __block PHObjectPlaceholder *placeholder;
+    
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+        
+        NSData *pngData = [NSData dataWithContentsOfURL:URL];
+        UIImage *image = [UIImage imageWithData:pngData];
+        _mChangeRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
+        placeholder = _mChangeRequest.placeholderForCreatedAsset;
+    } completionHandler:^(BOOL success, NSError *error) {
+        
+        if (success) {
+            NSURL *instagramURL = [NSURL URLWithString:[NSString stringWithFormat:@"instagram://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
+            
+            if ([[UIApplication sharedApplication] canOpenURL:instagramURL]) {
+                [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
+                if (successCallback != NULL) {
+                    successCallback(@[]);
+                }
+            }
+        }
+        else {
+            //Error while writing
+            if (failureCallback != NULL) {
+                failureCallback(error);
+            }
+        }
+    }];
+}
+
+- (NSURL *)fileURLWithTemporaryImageData:(NSData *)data {
+    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"instagram.ig"];
+    if (![data writeToFile:writePath atomically:YES]) {
+        return nil;
+    }
+    return [NSURL fileURLWithPath:writePath];
+}
+
 @end

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -93,11 +93,11 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
         if([social isEqualToString:@"facebook"]) {
             NSLog(@"TRY OPEN FACEBOOK");
             GenericShare *shareCtl = [[GenericShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeFacebook];
+            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeFacebook inAppBaseUrl:@"fb://"];
         } else if([social isEqualToString:@"twitter"]) {
             NSLog(@"TRY OPEN Twitter");
             GenericShare *shareCtl = [[GenericShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeTwitter];
+            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback serviceType: SLServiceTypeTwitter inAppBaseUrl:@"twitter://"];
         } else if([social isEqualToString:@"googleplus"]) {
             NSLog(@"TRY OPEN google plus");
             GooglePlusShare *shareCtl = [[GooglePlusShare alloc] init];

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -68,6 +68,15 @@
     }
 }
 
+- (BOOL)isImageMimeType:(NSString *)data {
+    NSRange range = [data rangeOfString:@"data:image" options:NSCaseInsensitiveSearch];
+    if (range.location != NSNotFound) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
@@ -109,7 +118,11 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
         } else if([social isEqualToString:@"instagram"]) {
             NSLog(@"TRY OPEN instagram");
             InstagramShare *shareCtl = [[InstagramShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            if([self isImageMimeType:options[@"url"]]) {// Condition to handle image
+                [shareCtl shareSingleImage:options failureCallback: failureCallback successCallback: successCallback];
+            } else {
+                [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            }
         } else if([social isEqualToString:@"email"]) {
             NSLog(@"TRY OPEN email");
             EmailShare *shareCtl = [[EmailShare alloc] init];


### PR DESCRIPTION
* Fix for Facebook and Twitter shareSingle is not working on iOS 11.
* Handled the image share option on Instagram.