### PR TITLE
Only call successCallback when completed is true (iOS 13 crash)

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -190,7 +190,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
         if (activityError) {
             failureCallback(activityError);
-        } else {
+        } else if (completed) {
             successCallback(@[@(completed), RCTNullIfNil(activityType)]);
         }
     };


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixes #583.

Currently on iOS 13 the app will crash if you:
- Open the share sheet
- Tap something like messages or photos
- Cancel the dialog
- Perform any other action

This is because `shareController.completionWithItemsHandler` is called when the dialog box is canceled and currently `failureCallback` or `successCallback` will always be called. In the situation above, `activityError` is `nil` so `successCallback` will be called even though `completed` is false. This leaves us in a state where the callback has been invoked but the ShareSheet is still active, meaning the success or error callback will be invoked again, leading to the crash.

This PR adds a check to make sure `completed` is true before calling `successCallback`. This way `successCallback` will only be called when the user has successfully completed an action and the ShareSheet is closed.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
- Saved an image successfully
- Opened and dismissed the `Photos` dialog multiple times without crashing