### PR TITLE
Update and fix Gradle setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,12 +22,16 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
-# Android/IJ
+# Android/IntelliJ
 #
-*.iml
+build/
 .idea
 .gradle
 local.properties
+*.iml
+android/gradle/
+android/gradlew
+android/gradlew.bat
 
 # Visual Studio
 *.VC.db
@@ -57,11 +61,3 @@ coverage
 
 # node-waf configuration
 .lock-wscript
-
-# Compiled binary addons (http://nodejs.org/api/addons.html)
-build/Release
-
-# Dependency directory
-# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-node_modules
-build/

--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,1 @@
-.babelrc
-.flowconfig
-.eslintrc
-.gitignore
-.github/*
-.circleci/*
-jsconfig.json
-commitlint.config.js
-changelog.js
-assets/*
-example/*
+example/

--- a/android/.npmignore
+++ b/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,16 +3,17 @@ def safeExtGet(prop, fallback) {
 }
 
 buildscript {
-    repositories {
-        google()
-        maven {
-          url 'https://maven.google.com'
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
         }
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.2'
+        }
     }
 }
 
@@ -21,13 +22,9 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
-
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
-
-        versionCode 1
-        versionName "1.0.0"
     }
     lintOptions {
         abortOnError false
@@ -36,17 +33,20 @@ android {
 }
 
 repositories {
-    google()
-    jcenter()
+    mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
+    maven {
+        // Android JSC is installed from npm
+        url "$rootDir/../node_modules/jsc-android/dist"
+    }
+    google()
     jcenter()
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:+"
-    //noinspection GradleCompatible
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
 }

--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,0 +1,6 @@
+*/project.xcworkspace/
+*/xcuserdata/
+.DS_Store
+.npmignore
+Pods/
+build/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
     "type": "git",
     "url": "git+https://github.com/react-native-community/react-native-share.git"
   },
+  "main": "index.js",
+  "files": [
+    "android",
+    "components",
+    "ios",
+    "windows",
+    "RNShare.podspec"
+  ],
   "devDependencies": {
     "@commitlint/cli": "8.1.0",
     "@commitlint/config-conventional": "8.1.0",


### PR DESCRIPTION
# Overview

## Android Gradle plugin

This wraps the Android Gradle plugin dependency in the `buildscripts` section of `android/build.gradle` in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

A small change with a big impact: 
The Android Gradle plugin is _only_ required when opening the project _stand-alone_, not when it is _included as a dependency_. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project **without** affecting the app project (avoiding unnecessary downloads/conflicts/etc).

## Gradle wrapper

Similarly, the Gradle wrapper (and related scripts) are only required for stand-alone editing/building of the `android` folder. It should _not_ be distributed. Android Studio will automatically generate a wrapper, or alternatively one can be generated on the command line on-the-fly (see below).

**UPDATE 2019-11-19**: Due to CI changes since this PR was opened, the Gradle wrapper has temporarily been added back. It will be removed in a follow-up PR that also includes other simplifications to the CI config.

## Support lib conflict

There was also an `appcompat-v7` leftover in build.gradle which caused the following error in Android Studio:

```
ERROR: Manifest merger failed : Attribute application@appComponentFactory value=(androidx.core.app.CoreComponentFactory) from [androidx.core:core:1.0.1] AndroidManifest.xml:22:18-86
	is also present at [com.android.support:support-compat:28.0.0] AndroidManifest.xml:22:18-91 value=(android.support.v4.app.CoreComponentFactory).
	Suggestion: add 'tools:replace="android:appComponentFactory"' to <application> element at manifestMerger6643979123070804112.xml:7:5-9:19 to override.
```

Since this project has already been converted to AndroidX, and React Native 0.60+ pulls in the androidx dependencies, this line is no longer needed.

## .npmignore config

In a separate commit, this PR also includes a small update to the npmignore config of the project. By defining precisely which files get added to the distributed archive, along with excluding things like the Gradle wrapper jar a significant size reduction of the distribution artifact to almost a third of the previous value was achieved:

Before:

```
npm notice === Tarball Details ===
npm notice name:          react-native-share
npm notice version:       2.0.0
npm notice filename:      react-native-share-2.0.0.tgz
npm notice package size:  91.1 kB
npm notice unpacked size: 224.2 kB
npm notice total files:   65
```

After:

```
npm notice name:          react-native-share
npm notice version:       2.0.0
npm notice filename:      react-native-share-2.0.0.tgz
npm notice package size:  35.9 kB
npm notice unpacked size: 159.3 kB
npm notice total files:   57
```

## Test Plan

### What's required for testing (prerequisites)?

Android Studio and/or Gradle installed locally.

### What are the steps to reproduce (after prerequisites)?

Open `android` in Android Studio:

```sh
studio android/
```

Or:

Generate a Gradle wrapper on the fly, and build on command line:

```sh
cd android/
gradle wrapper --gradle-version 5.4.1 --distribution-type all
./gradlew build
```

Successfully verified and tested on:
- Android Device (Xiaomi Mi A2)
- Android Emulator (Pixel 3a)
- iOS Device (iPhone 8)
- iOS Simulator (iPhone X)

<sub><sup>Once approved, please use a *normal* GitHub merge (i.e. **NO rebase/squash** merge) to integrate the commit(s) from the PR head branch. The changes are broken up into meaningful, [atomic commits](https://www.freshconsulting.com/atomic-commits/), and my branch should already be up-to-date with the latest base branch. If it isn't, or if you want me to change anything, please let me know, and I will update the branch as soon as possible. Thank you!</sup></sub>