### PR TITLE
iOS 13: Resolve promise if ShareSheet is manually dismissed

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -190,7 +190,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
         if (activityError) {
             failureCallback(activityError);
-        } else if (completed) {
+        } else if (completed || activityType == nil) {
             successCallback(@[@(completed), RCTNullIfNil(activityType)]);
         }
     };


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixes #601.

This PR fixes an issue on iOS 13 where the ShareSheet's promise isn't resolved if the user closes the sheet without completing any actions introduced in #584.

This PR changes the `if (completed)` check in `completionWithItemsHandler` to `if (completed || activityType == nil)`

It looks like in `completionWithItemsHandler` the activityType will only be `nil` if the user closed the ShareSheet themselves, like so:

<img width="406" alt="Screen Shot 2019-10-14 at 1 41 22 PM" src="https://user-images.githubusercontent.com/7979579/66775162-0139b480-ee89-11e9-91e0-b657541af606.png">

Here's when they close the reminders modal:
<img width="515" alt="Screen Shot 2019-10-14 at 1 43 02 PM" src="https://user-images.githubusercontent.com/7979579/66775185-0eef3a00-ee89-11e9-8915-3cd4abc35fd9.png">

And the photos modal:
<img width="494" alt="Screen Shot 2019-10-14 at 1 47 03 PM" src="https://user-images.githubusercontent.com/7979579/66775212-1f9fb000-ee89-11e9-8037-9d15dd1bcd51.png">

This should fix the current issue without reintroducing the crash.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
- Ensure promise is resolved when the ShareSheet is closed manually
- Ensure the promise is **not** resolved when a different modal is dismissed (photos, add to contact, reminders, etc)
