### PR TITLE
fix: added missing "v" to `source` field in podspec

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author             = { "Esteban Fuentealba" => "efuentealba@json.cl" }
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/react-native-community/react-native-share.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-share.git", :tag => "v#{s.version}" }
 
   s.source_files  = "ios/**/*.{h,m}"
 


### PR DESCRIPTION
The tags are being named with a "v" and as such, the podspec needs to resolve the tags by including the "v" in the `source` field

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Without this fix, users are unable to link the library via CocoaPods. The Cocoapods install fails because it is unable to resolve the `source` of the pod.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
