### PR TITLE
Add some info about iOS installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ We recommend using the releases from npm, however you can use the master branch 
 ``` 
 yarn add react-native-share@git+https://git@github.com/react-native-community/react-native-share.git
 ```
+---
+
+#### LSApplicationQueriesSchemes on iOS
+Remember to add `instagram`, `facebook` or watever queries schemes you need to LSApplicationQueriesSchemes
+field in your Info.plist. This is required to share content directly to other apps like Instagram, Facebook etc.  
+Values for queries schemes can be found in `Social` field of `RNShare` class.
 
 
 


### PR DESCRIPTION
As per request from here: https://github.com/react-native-community/react-native-share/issues/320

@jgcmarins

# Overview
To make it possible to share directly to other apps, users need to specify queries schemes in LSApplicationQueriesSchemes in their Info.plist files. I've made README more explicit about that.

No code was changed.