### PR TITLE
Set maxWorkers to 2 for example project

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -14,4 +14,5 @@ module.exports = {
       },
     }),
   },
+  maxWorkers: 2,
 };


### PR DESCRIPTION
The CI is currently failing with

```
> Process 'command 'npx'' finished with non-zero exit value 137
```

The error can be fixed with the proposed change to set `maxWorkers` to `2` in the metro config for the example project. While it would be nice to set this value on _CI only_, I have not found a different/better way to do it.