### PR TITLE
Enables sending text via WhatsApp on iOS to a specific phone number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# react-native-share [![CircleCI](https://circleci.com/gh/react-native-community/react-native-share/tree/master.svg?style=svg&circle-token=0c6860240abba4e16bd07df0ea805a72b67b8d41)](https://circleci.com/gh/react-native-community/react-native-share/tree/master) [![npm version](https://badge.fury.io/js/react-native-share.svg)](http://badge.fury.io/js/react-native-share)
+# react-native-share [![CircleCI](https://circleci.com/gh/react-native-community/react-native-share/tree/master.svg?style=svg&circle-token=0c6860240abba4e16bd07df0ea805a72b67b8d41)](https://circleci.com/gh/react-native-community/react-native-share/tree/master) [![npm version](https://badge.fury.io/js/react-native-share.svg)](http://badge.fury.io/js/react-native-share)
 React Native Share, a simple tool for share message and file to other apps.
 
 # Sponsors
@@ -250,7 +250,7 @@ const shareOptions = {
     message: 'some message',
     url: 'some share url',
     social: Share.Social.WHATSAPP,
-    whatsAppNumber: "9199999999",  // country code + phone number(currently only works on Android)
+    whatsAppNumber: "9199999999",  // country code + phone number
     filename: 'test' , // only for base64 file in Android 
 };
 Share.shareSingle(shareOptions);

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -20,6 +20,7 @@ RCT_EXPORT_MODULE();
     if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
         NSString *text = [RCTConvert NSString:options[@"message"]];
         text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
+        NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
 
         if ([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
             NSLog(@"WhatsApp installed");
@@ -49,7 +50,7 @@ RCT_EXPORT_MODULE();
         } else {
             text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
             
-            NSString * urlWhats = [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
+            NSString * urlWhats = whatsAppNumber ? [NSString stringWithFormat:@"whatsapp://send?phone=%@&text=%@", whatsAppNumber, text] : [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
             NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
     
             if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Currently, sending texts to a whatsAppNumber is not supported on iOS, this pull request proposes to mitigate this issue.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested in my iPhone XR.

![whatsapp](https://user-images.githubusercontent.com/2258901/75180966-fedf4500-571b-11ea-9917-f11aa0d3549c.png)