### PR TITLE
iOS: Hide view controller on activityError

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -238,6 +238,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
 
     shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
         if (activityError) {
+            [controller  dismissViewControllerAnimated:true completion:nil];
             failureCallback(activityError);
         } else if (completed || activityType == nil) {
             successCallback(@[@(completed), RCTNullIfNil(activityType)]);


### PR DESCRIPTION
# Overview
Package keep crashing app in DEV mode when user cancel and open "Save to files" option on iOS. 
Solution is to hide action sheet on activityError to prevent callbacks to be called numerous times.
Related issue: https://github.com/react-native-community/react-native-share/issues/659

# Test Plan
1. Open action sheet.
2. Choose Save to files option and cancel. 
3. Repeat second point
4. Now whole action sheet should hide


