### PR TITLE
Support sharing of files from secondary storage i.e sd cards, on Android

### DIFF
--- a/android/src/main/java/cl/json/RNSharePathUtil.java
+++ b/android/src/main/java/cl/json/RNSharePathUtil.java
@@ -57,7 +57,7 @@ public class RNSharePathUtil {
                     break;
                 }
             } catch (Exception e) {
-
+                System.out.println("ERROR " + e.getMessage());
             }
         }
         return result;

--- a/android/src/main/java/cl/json/RNSharePathUtil.java
+++ b/android/src/main/java/cl/json/RNSharePathUtil.java
@@ -57,7 +57,7 @@ public class RNSharePathUtil {
                     break;
                 }
             } catch (Exception e) {
-                System.out.println("ERROR " + e.getMessage());
+                System.out.println("RNSharePathUtil::compatUriFromFile ERROR " + e.getMessage());
             }
         }
         return result;

--- a/android/src/main/res/xml/share_download_paths.xml
+++ b/android/src/main/res/xml/share_download_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="rnshare1" path="Download/" />
     <cache-path name="rnshare2" path="/" />
+    <root-path name="rnshare_sdcard" path="." />
 </paths>


### PR DESCRIPTION


# Overview
Currently the Android config does not support sharing of files from secondary storage (sd cards). Developers/users have used the base64 workaround for this, but I thought it would be a good idea to support it.
Also none of these would solve it:

```
  <external-files-path
    name="external_files"
    path="." />
  <external-cache-path
    name="external_cache"
    path="." />
<files-path
    name="files"
    path="." />

```
# Test Plan
On an emulator or device, download an image to the sdcard or "external storage" and then share it.