### PR TITLE
Only convert options.url to options.urls in iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class RNShare {
     return new Promise((resolve, reject) => {
       requireAndAskPermissions(options)
         .then(() => {
-          if (options.url && !options.urls) {
+          if (Platform.OS === 'ios' && options.url && !options.urls) {
             // Backward compatibility with { Share } from react-native
             const url = options.url;
             delete options.url;


### PR DESCRIPTION
# Overview
In Android this behaviour would result in `Intent.ACTION_SEND_MULTIPLE` instead of `Intent.ACTION_SEND` for a single file. Some apps could support one, but not another.


# Test Plan
I've checked in on a real device using https://f-droid.org/en/packages/de.k3b.android.intentintercept/
