### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ npm install react-native-share --save
 2. iOS 13 SDK or higher
 
 #### Important:
+
 Linking is not needed anymore. ``react-native@0.60.0+`` supports dependencies auto linking.
-For iOS you also need additional step to install auto linked Pods (Cocoapods should be installed):
-```
-cd ios && pod install && cd ../
+For iOS you also need additional step to install auto linked Pods:
+```sh
+npx pod-install
 ```
 ___
 


### PR DESCRIPTION
We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.
