### PR TITLE
Set react peer dep to 16.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "minimist": "1.2.5",
     "pre-commit": "1.2.2",
     "prettier": "^2.0.5",
-    "react": "16.13.1",
+    "react": "16.11.0",
     "react-native": "0.62.2",
     "semantic-release": "^17.0.4",
     "simple-git": "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7311,10 +7311,10 @@ react-refresh@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"
   integrity sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ==
 
-react@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+react@16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Small update to align the `react` dependency with `react-native`.

Fixes

```
warning " > react-native@0.62.2" has incorrect peer dependency "react@16.11.0".
```