### PR TITLE
Changing CircleCI config to use react-native orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
           root: .
           paths:
             - node_modules
-
     
   lint:
     executor: react-native/linux_js
@@ -41,6 +40,14 @@ jobs:
       - run:
           name: Lint
           command: yarn lint
+
+  validate-flow:
+    executor: react-native/linux_js
+    steps:
+      - checkout-attach-workspace
+      - run:
+          name: Lint
+          command: yarn validate:flow
   
   build-example-app:
     executor: react-native/linux_android
@@ -70,6 +77,9 @@ workflows:
           requires:
             - install-dependencies          
       - lint:
+          requires:
+            - install-dependencies
+      - validate-flow:
           requires:
             - install-dependencies
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,12 @@ jobs:
     executor: react-native/linux_js
     steps:
       - checkout-attach-workspace
-      - react-native/yarn_install
+      - react-native/yarn_install  
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+
     
   lint:
     executor: react-native/linux_js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-            at: ~/app
+            at: .
 
   dev-sync-files:
     description: "Copy files from root to example"
@@ -28,13 +28,8 @@ jobs:
     steps:
       - checkout-attach-workspace
       - react-native/yarn_install
-      - persist_to_workspace:
-          root: ~/app
-          paths:
-            - node_modules
     
   lint:
-    working_directory: ~/app
     executor: react-native/linux_js
     steps:
       - checkout-attach-workspace
@@ -43,7 +38,6 @@ jobs:
           command: yarn lint
   
   build-example-app:
-    working_directory: ~/app
     executor: react-native/linux_android
     steps:
       - checkout-attach-workspace
@@ -52,7 +46,6 @@ jobs:
           project_path: ./example/android
       
   publish-version:
-    working_directory: ~/app
     executor: react-native/linux_js
     steps:
       - checkout-attach-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - checkout-attach-workspace
       - run:
-          name: Lint
+          name: Flow
           command: yarn validate:flow
   
   build-example-app:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ jobs:
           name: Lint
           command: yarn lint
   
+  build-example-app:
+    working_directory: ~/app
+    executor: react-native/linux_android
+    steps:
+      - checkout-attach-workspace
+      - dev-sync-files
+      - react-native/android_build:
+          project_path: ./example/android
+      
   publish-version:
     working_directory: ~/app
     executor: react-native/linux_js
@@ -59,6 +68,9 @@ workflows:
   build-lint-app:
     jobs:
       - install-dependencies
+      - build-example-app:
+          requires:
+            - install-dependencies          
       - lint:
           requires:
             - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,121 +1,75 @@
-version: 2
-executorType: docker
-jobs:
-  install-dependencies:
-    working_directory: ~/app
-    docker:
-      - image: reactnativecommunity/react-native-android
+version: 2.1
+
+orbs:
+  react-native: react-native-community/react-native@4.4.0
+
+commands:
+  checkout-attach-workspace:
+    description: "Checkout and attach workspace"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - v1-npm
+      - attach_workspace:
+            at: ~/app
+
+  dev-sync-files:
+    description: "Copy files from root to example"
+    steps:
+      - checkout-attach-workspace
       - run:
-          name: Install Dependencies
-          command: yarn install --frozen-lockfile --non-interactive
-      - save_cache:
-          key: v1-npm
-          paths:
-            - node_modules/
-      - save_cache:
-          key: v1-npm-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules/
+          name: "Enter example app"
+          command: cd example && yarn install --frozen-lockfile --non-interactiv
+      - run:
+          name: "Sync files with example app"
+          command: yarn dev-sync
+
+jobs:
+  install-dependencies:
+    executor: react-native/linux_js
+    steps:
+      - checkout-attach-workspace
+      - react-native/yarn_install
       - persist_to_workspace:
           root: ~/app
           paths:
             - node_modules
+    
   lint:
     working_directory: ~/app
-    docker:
-      - image: reactnativecommunity/react-native-android
+    executor: react-native/linux_js
     steps:
-      - checkout
-      - attach_workspace:
-          at: ~/app
+      - checkout-attach-workspace
       - run:
           name: Lint
           command: yarn lint
-  build-example-app:
-    working_directory: ~/app
-    docker:
-      - image: reactnativecommunity/react-native-android
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/app
-      - restore_cache:
-          keys:
-            - v1-gradle-{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "example/android/gradle/wrapper/gradle-wrapper.properties" }}
-            - v1-gradle-wrapper
-      - restore_cache:
-          keys:
-            - v1-gradle-cache-{{ checksum "android/build.gradle" }}-{{ checksum "example/android/build.gradle" }}
-            - v1-gradle-cache
-      - run:
-          name: Run Gradle Checks on Example App
-          command: |
-            cd android
-            chmod +x ./gradlew
-            ./gradlew clean && ./gradlew && ./gradlew check
-      - store_artifacts:
-          path: android/build/reports
-      - run:
-          name: Install dependencies on the example app
-          command: cd example && yarn install --frozen-lockfile --non-interactive
-      - run:
-          name: Check for errors in the example app using Flow
-          command: |
-            cd example && yarn flow
-      - run:
-          name: Dev Sync #sync code on the current version to the example app
-          command: yarn dev-sync
-      - run:
-          name: Build Sample App
-          command: |
-            cd example/android && chmod +x ./gradlew && ./gradlew build
-      - store_artifacts:
-          path: example/android/app/build/reports
-          destination: app
-      - save_cache:
-          key: v1-gradle-wrapper-{{ checksum "example/android/gradle/wrapper/gradle-wrapper.properties" }}
-          paths:
-            - ~/.gradle/wrapper
-      - save_cache:
-          key: v1-gradle-cache-{{ checksum "example/android/build.gradle" }}
-          paths:
-            - ~/.gradle/caches
+  
   publish-version:
     working_directory: ~/app
-    docker:
-      - image: reactnativecommunity/react-native-android
+    executor: react-native/linux_js
     steps:
-      - checkout
+      - checkout-attach-workspace
       - attach_workspace:
           at: ~/app
       - run:
           name: Publish New Version
           command: yarn ci:publish
+
 workflows:
   version: 2
+
   build-lint-app:
     jobs:
       - install-dependencies
       - lint:
           requires:
             - install-dependencies
-          filters:
-            branches:
-              ignore:
-                - master
-      - build-example-app:
-          requires:
-            - lint
-      - publish-version:
-          requires:
-            - install-dependencies
+  
+  release:
+    jobs:
+      - install-dependencies:
           filters:
             branches:
               only:
                 - master
+      - publish-version:
+          requires:
+            - install-dependencies

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -198,4 +198,17 @@ task copyDownloadableDepsToLibs(type: Copy) {
     into 'libs'
 }
 
+task downloadDependencies() {
+  description 'Download all dependencies to the Gradle cache'
+  doLast {
+    configurations.findAll().each { config ->
+      if (config.name.contains("minReactNative") && config.canBeResolved) {
+        print config.name
+        print '\n'
+        config.files
+      }
+    }
+  }
+}
+
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)


### PR DESCRIPTION
# Overview
This PR changes the basic config at `circle.yml`  to use [react-native-orb](https://circleci.com/orbs/registry/orb/react-native-community/react-native) directly. Leading to a an abstraction of some commands like `android build`, etc.

# Test Plan
Check if the CI still working without problems 👯 