### PR TITLE
feat: adding recipient for sms on Android

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -121,18 +121,10 @@ public abstract class ShareIntent {
         }
 
         if (socialType.equals("sms")) {
-            String[] recipientsArray = options.getArray("recipients");
-            String separator = ",";
-            if(android.os.Build.MANUFACTURER.equals("Samsung")){
-                separator = ";";
-            }
-            String recipients = "";
-            for (int i = 0; i < recipientsArray.size(); i++) {
-                recipients += recipientsArray.getString(i);
-                recipients += separator;
-            }
-            if (!recipients.isEmpty()) {
-                this.getIntent().putExtra("address", recipients);
+            String recipient = options.getString("recipient");
+
+            if (!recipient.isEmpty()) {
+                this.getIntent().putExtra("address", recipient);
             }
         }
 

--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -120,6 +120,22 @@ public abstract class ShareIntent {
             socialType = options.getString("social");
         }
 
+        if (socialType.equals("sms")) {
+            String[] recipientsArray = options.getArray("recipients");
+            String separator = ",";
+            if(android.os.Build.MANUFACTURER.equals("Samsung")){
+                separator = ";";
+            }
+            String recipients = "";
+            for (int i = 0; i < recipientsArray.size(); i++) {
+                recipients += recipientsArray.getString(i);
+                recipients += separator;
+            }
+            if (!recipients.isEmpty()) {
+                this.getIntent().putExtra("address", recipients);
+            }
+        }
+
         if (socialType.equals("whatsapp")) {
             String whatsAppNumber = options.getString("whatsAppNumber");
             if (!whatsAppNumber.isEmpty()) {

--- a/example/App.js
+++ b/example/App.js
@@ -23,6 +23,7 @@ import images from './images/imagesBase64';
 
 const App = () => {
   const [packageSearch, setPackageSearch] = useState<string>('');
+  const [recipient, setRecipient] = useState<string>('');
   const [result, setResult] = useState<string>('');
 
   /**
@@ -155,6 +156,23 @@ const App = () => {
     }
   };
 
+  const shareSms = async () => {
+    const shareOptions = {
+      title: '',
+      social: Share.Social.SMS,
+      recipient,
+      message: 'Example SMS',
+    };
+
+    try {
+      const ShareResponse = await Share.shareSingle(shareOptions);
+      setResult(JSON.stringify(ShareResponse, null, 2));
+    } catch (error) {
+      console.log('Error =>', error);
+      setResult('error: '.concat(getErrorString(error)));
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.welcome}>Welcome to React Native Share Example!</Text>
@@ -177,20 +195,34 @@ const App = () => {
           </View>
         )}
         {Platform.OS === 'android' && (
-          <View style={styles.searchPackageContainer}>
-            <TextInput
-              placeholder="Search for a Package"
-              onChangeText={setPackageSearch}
-              value={packageSearch}
-              style={styles.textInput}
-            />
-            <View>
-              <Button
-                onPress={checkIfPackageIsInstalled}
-                title="Check Package"
+          <>
+            <View style={styles.withInputContainer}>
+              <TextInput
+                placeholder="Recipient"
+                onChangeText={setRecipient}
+                value={recipient}
+                style={styles.textInput}
+                keyboardType="number-pad"
               />
+              <View>
+                <Button onPress={shareSms} title="Share Social: SMS" />
+              </View>
             </View>
-          </View>
+            <View style={styles.withInputContainer}>
+              <TextInput
+                placeholder="Search for a Package"
+                onChangeText={setPackageSearch}
+                value={packageSearch}
+                style={styles.textInput}
+              />
+              <View>
+                <Button
+                  onPress={checkIfPackageIsInstalled}
+                  title="Check Package"
+                />
+              </View>
+            </View>
+          </>
         )}
         <Text style={styles.resultTitle}>Result</Text>
         <Text style={styles.result}>{result}</Text>
@@ -230,7 +262,7 @@ const styles = StyleSheet.create({
   optionsRow: {
     justifyContent: 'space-between',
   },
-  searchPackageContainer: {
+  withInputContainer: {
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ type Options = {
   message?: string,
   title?: string,
   subject?: string,
+  recipient?: string,
   excludedActivityTypes?: string,
   failOnCancel?: boolean,
   showAppsToView?: boolean,
@@ -216,6 +217,7 @@ class RNShare {
     EMAIL: NativeModules.RNShare.EMAIL || 'email',
     PINTEREST: NativeModules.RNShare.PINTEREST || 'pinterest',
     LINKEDIN: NativeModules.RNShare.LINKEDIN || 'linkedin',
+    SMS: NativeModules.RNShare.SMS || 'sms',
   };
 
   static InstagramStories = {

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -36,6 +36,7 @@ You can customize the call to `Share.open` passing the following parameters:
 | type | string   | File mime type | ✅ | ✅ | ✅  | ❓
 | subject | string   | Subject sent when sharing to email | ✅ | ✅ | ✅  | ❓
 | email | string   | Email of addressee | ✅ | ✅ | ✅  | ❓
+| recipient | string | Phone number of SMS recipient | ✅ | ✅ | 🚫 | 🚫
 | excludedActivityTypes | Array[string] |  Activity types that won't show in the Share dialog | 🚫 | ✅ | ✅  | ❓
 | failOnCancel | boolean | (defaults to true) Specifies whether promise should reject if user cancels share dialog | ✅ | ✅ | ✅ | ❓
 | showAppsToView | boolean | only android | ✅ | ✅ | 🚫 | ❓

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -51,6 +51,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | title | string   |  Title sent to the share activity | ✅ |  ✅ | ✅ | ❓
 | subject | string   | Subject sent when sharing to email | ✅ | ✅ | ✅  | ❓
 | email | string   | Email of addressee | ✅ | ✅ | ✅  | ❓
+| recipient | string | Phone number of SMS recipient | ✅ | ✅ | 🚫 | 🚫
 | social | string   | supported social apps: [List](#static-values-for-social)  | 🚫 | ✅ | ✅  | ❓
 | forceDialog | boolean | (optional) only android. Avoid showing dialog with buttons Just Once / Always. Useful for Instagram to always ask user if share as Story or Feed | ✅ | ✅ | ✅  | ❓
 


### PR DESCRIPTION
# Overview
Add an optional field `recipient` for SMS destination recipient, resolves #812.

When choosing to share using SMS, you can include one recipient as a string. For example: 
```js
Share.shareSingle({
      title: 'Hello SMS!',
      social: Share.Social.SMS,
      recipient: '123-4567890',
      message: 'Example SMS message',
});
```

### But why not multiple recipients?

Different vendors have different formatting when specifying multiple destination phone numbers. And also, some vendors do not even support adding multiple destination phone numbers when using the `ACTION_SEND` intent. Which would require the `ACTION_SENDTO` intent. However, could be implemented in the future.

# Test Plan
Test it through the example app.

![recipient-example](https://user-images.githubusercontent.com/10698008/85950036-9a96f100-b95a-11ea-877e-4d5ea1616e01.gif)

