### PR TITLE
Update Info.plist in Examples

### DIFF
--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -28,7 +28,7 @@
 	<array>	
 	    <string>instagram-stories</string>	
         <string>instagram</string>	
-		<string>facebook</string>	
+		<string>fb</string>	
 		<string>whatsapp</string>	
 		<string>mailto</string>	
 	</array>


### PR DESCRIPTION
This PR aims to clarify the issues faced when trying to implement singleShare for facebook. More specifically, specifying `facebook` in the `Info.plist` does not necessitate the ability to share on facebook since the matching string is `fb`.

By updating the `example/Info.plist`, users will be able to accurately understand what is needed in order to integrate facebook sharing functionality.

This should help provide an answer to the issues faced here:

https://github.com/react-native-community/react-native-share/issues/384

# Overview

Updating the `Info.plist` to accurately reflect the facebook string expected in order to improve documentation and allow for facebook sharing