### PR TITLE
Fixes for some bugs with Instagram Stories on Android

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -142,7 +142,7 @@ public abstract class ShareIntent {
                 switch (method) {
                     case "shareBackgroundImage": {
                         if (ShareIntent.hasValidKey("backgroundImage", options)) {
-                            this.backgroundAsset = new ShareFile(options.getString("backgroundImage"), "image/jpeg", "background", this.reactContext);
+                            this.backgroundAsset = new ShareFile(options.getString("backgroundImage"), "background", this.reactContext);
                             this.getIntent().setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
                             this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
@@ -157,8 +157,16 @@ public abstract class ShareIntent {
                     case "shareStickerImage": {
                         if (ShareIntent.hasValidKey("stickerImage", options)) {
                             this.getIntent().setType("image/jpeg");
-                            this.stickerAsset = new ShareFile(options.getString("stickerImage"), "image/jpeg", "sticker", this.reactContext);
+                            this.stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", this.reactContext);
                             this.getIntent().putExtra("interactive_asset_uri", stickerAsset.getURI());
+                            Activity activity = this.reactContext.getCurrentActivity();
+                            if (activity == null) {
+                                TargetChosenReceiver.sendCallback(false, "Something went wrong");
+                                return;
+                            }
+                            activity.grantUriPermission(
+                                    "com.instagram.android", stickerAsset.getURI(), Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            );
 
                             if (ShareIntent.hasValidKey("attributionURL", options)) {
                                 this.getIntent().putExtra("content_url", options.getString("attributionURL"));
@@ -184,6 +192,14 @@ public abstract class ShareIntent {
                             this.getIntent().setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
                             this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                             this.getIntent().putExtra("interactive_asset_uri", stickerAsset.getURI());
+                            Activity activity = this.reactContext.getCurrentActivity();
+                            if (activity == null) {
+                                TargetChosenReceiver.sendCallback(false, "Something went wrong");
+                                return;
+                            }
+                            activity.grantUriPermission(
+                                    "com.instagram.android", stickerAsset.getURI(), Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            );
 
                             if (ShareIntent.hasValidKey("attributionURL", options)) {
                                 this.getIntent().putExtra("content_url", options.getString("attributionURL"));

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -71,20 +71,8 @@ public abstract class SingleShareIntent extends ShareIntent {
                 return;
             }
             if (options != null) {
-                if (ShareIntent.hasValidKey("social", options)) {
-                    String socialType = options.getString("social");
-                    if (socialType.equals("instagramstories")) {
-                        if (ShareIntent.hasValidKey("method", options)) {
-                            String method = options.getString("method");
-                            if (method.equals("shareStickerImage") || method.equals("shareBackgroundAndStickerImage")) {
-                                activity.grantUriPermission("com.instagram.android", this.stickerAsset.getURI(), Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                            }
-                        } else {
-                            throw new java.lang.IllegalArgumentException("instagram share mode is empty");
-                        }
-                    }
-                } else {
-                    throw new java.lang.IllegalArgumentException("social is empty");
+                if (!ShareIntent.hasValidKey("social", options)) {
+                    throw new IllegalArgumentException("social is empty");
                 }
             }
             if (TargetChosenReceiver.isSupported()) {

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -99,7 +99,7 @@ public abstract class SingleShareIntent extends ShareIntent {
                 TargetChosenReceiver.sendCallback(true, true, "OK");
             }
         } else {
-            this.getIntent().setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            this.getIntent().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             this.reactContext.startActivity(this.getIntent());
             TargetChosenReceiver.sendCallback(true, true, this.getIntent().getPackage());
         }

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -38,6 +38,7 @@ public abstract class SingleShareIntent extends ShareIntent {
                     this.getIntent().setPackage(getPackage());
                 }
                 super.open(options);
+                return; // once we open we don't need to continue
             } else {
                 System.out.println("NOT INSTALLED");
                 String url = "";


### PR DESCRIPTION
# Overview

There were a couple of shortcomings when trying to share Instagram Stories on Android. `base64` would _not_ work on a file of any decent size. The flags on the intents were not set correctly, so Instagram was not able to open the image after it was sent. Stickers could only be sent if you were using `forceDialog`.

I've just upstreamed the changes I made at work to get Instagram Stories to work in our app.

Fixes #852 
Fixes #853 
Fixes #854 
Fixes #855

# Test Plan

There are no tests for Android currently. I have patched these changes into the app at work, and they all work as expected (for us), so I'm upstreaming them