### PR TITLE
Check if whatsAppNumber key exists before get it

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -129,8 +129,8 @@ public abstract class ShareIntent {
         }
 
         if (socialType.equals("whatsapp")) {
-            String whatsAppNumber = options.getString("whatsAppNumber");
-            if (!whatsAppNumber.isEmpty()) {
+            if (options.hasKey("whatsAppNumber")) {
+                String whatsAppNumber = options.getString("whatsAppNumber");
                 String chatAddress = whatsAppNumber + "@s.whatsapp.net";
                 this.getIntent().putExtra("jid", chatAddress);
             }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

When try to share a file or message via WhatsApp with no number receive a error:

```js
        Share.shareSingle({
            title: 'Foo',
            url: 'path/to/my/file',
            social: Share.Social.WHATSAPP,
        });
```

Error:

```java
com.facebook.react.bridge.NoSuchKeyException: whatsAppNumber
    at com.facebook.react.bridge.ReadableNativeMap.getNullableValue(ReadableNativeMap.java:122)
    at com.facebook.react.bridge.ReadableNativeMap.getNullableValue(ReadableNativeMap.java:126)
    at com.facebook.react.bridge.ReadableNativeMap.getString(ReadableNativeMap.java:161)
    at cl.json.social.ShareIntent.open(ShareIntent.java:132)
    at cl.json.social.SingleShareIntent.open(SingleShareIntent.java:40)
    at cl.json.social.WhatsAppShare.open(WhatsAppShare.java:21)
    at cl.json.RNShareModule.shareSingle(RNShareModule.java:158)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:371)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:150)
    at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:26)
    at android.os.Looper.loop(Looper.java:237)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:225)
    at java.lang.Thread.run(Thread.java:919)
```


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Just try to call `Share.shareSingle` with `Share.Social.WHATSAPP` and no `whatsAppNumber`.