### PR TITLE
fix: use documented Platform.version for backwards compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ import Sheet from './components/Sheet';
 import Button from './components/Button';
 
 const ANDROID_KIT_KAT_SDK_VERSION = 19;
-const androidPermissionRequestRequired = Platform.constants.Version < ANDROID_KIT_KAT_SDK_VERSION;
+const androidPermissionRequestRequired = Platform.Version < ANDROID_KIT_KAT_SDK_VERSION;
 
 const styles = StyleSheet.create({
   actionSheetContainer: {


### PR DESCRIPTION
# Overview

The `Platform.constants` added in #871 is not available in RN versions before 0.61 as reported in #879. `Platform.Version` is still there, and it's documented so I've switched to that instead.

# Test Plan

Going to ask @alemarra89 if they can install this branch and test that it resolve the issue.
