### PR TITLE
Fix Flowtype error

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ import Sheet from './components/Sheet';
 import Button from './components/Button';
 
 const ANDROID_KIT_KAT_SDK_VERSION = 19;
-const androidPermissionRequestRequired = parseInt(Platform.Version) < ANDROID_KIT_KAT_SDK_VERSION;
+const androidPermissionRequestRequired =
+  parseInt(Platform.Version, 10) < ANDROID_KIT_KAT_SDK_VERSION;
 
 const styles = StyleSheet.create({
   actionSheetContainer: {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ import Sheet from './components/Sheet';
 import Button from './components/Button';
 
 const ANDROID_KIT_KAT_SDK_VERSION = 19;
-const androidPermissionRequestRequired = Platform.Version < ANDROID_KIT_KAT_SDK_VERSION;
+const androidPermissionRequestRequired = parseInt(Platform.Version) < ANDROID_KIT_KAT_SDK_VERSION;
 
 const styles = StyleSheet.create({
   actionSheetContainer: {


### PR DESCRIPTION
# Overview
A recent change to the repo has caused Flowtype check to fail.

`Platform.Version` returns a `string`, and cannot be directly compared to a number.

# Test Plan
- Run Flowtype check
- Confirm that the type checking passes
