### PR TITLE
fix(ios): thumbnail/preview does not shows up when using `singleShare` for WhatsApp

### DIFF
--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -72,8 +72,8 @@ resolve:(RCTPromiseResolveBlock)resolve {
         }
       
         image = [UIImage imageWithData: data];
-        NSString * documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-        NSString * filePath = [documentsPath stringByAppendingPathComponent:@"/whatsAppTmp.wai"];
+        NSString *tempPath = NSTemporaryDirectory();
+        NSString *filePath = [tempPath stringByAppendingPathComponent:@"image.jpg"];
         
         [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
       


### PR DESCRIPTION
Fixes the image thumbnail not showing up in system sharesheet

### Before 
![536732595-c040ff1c-7850-4c75-bdd7-1feb3026c1b4](https://github.com/user-attachments/assets/2ccaefbd-a255-493f-8d54-3c5fc5882a26)

### After
<img width="602" height="159" alt="537581767-029d2225-c49c-4ad0-8c4d-080440364b89" src="https://github.com/user-attachments/assets/5342a8df-0351-468b-98c2-56fa3eef4b0b" />
