### PR TITLE
Fix WhatsApp share on iOS

### DIFF
--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -113,7 +113,9 @@ resolve:(RCTPromiseResolveBlock)resolve {
              reject:(RCTPromiseRejectBlock)reject {
   
   NSString *text = [RCTConvert NSString:options[@"message"]];
-  text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
+  if (options[@"url"] && options[@"url"] != [NSNull null]) {
+    text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
+  }
   NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
   
   text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
@@ -129,6 +131,16 @@ resolve:(RCTPromiseResolveBlock)resolve {
 
 
 -(MessageType)getMessageType: (NSString *)url {
+  if (!url || url.length == 0) {
+    return MessageTypeText;
+  }
+  NSURL *parsed = [NSURL URLWithString:url];
+  NSString *scheme = parsed.scheme.lowercaseString;
+  BOOL isFileOrData = scheme && ([scheme isEqualToString:@"file"] || [scheme isEqualToString:@"data"]);
+  BOOL isAbsolutePath = [url hasPrefix:@"/"];
+  if (!isFileOrData && !isAbsolutePath) {
+    return MessageTypeText;
+  }
   NSArray *imageExtensions = @[@"png", @"jpeg",@"jpg",@"gif"];
   if([self isMediaType:url mediaExtensions: imageExtensions]){
     return MessageTypeImage;


### PR DESCRIPTION
# Fix WhatsApp share on iOS: only treat local/data URLs as media

Fixes bugs when sharing to WhatsApp on iOS with missing `url`, remote links (`https://`), or paths without `file://`. Now we only treat something as image/video/audio when it's actually a local file or data URI—same idea as Android's `ShareFile.isFile()`.

## Changes

**`getMessageType:`**
- If `url` is nil or empty → return text (no more misclassifying as image and then failing).
- Only consider media when the URL is `file://`, `data:`, or an absolute path starting with `/`. Everything else (e.g. `http://`, `https://`) → text, so the link goes in the message and the promise resolves instead of hanging or lying about success.

**`tryToSendText:`**
- Only append `options[@"url"]` when it exists and isn't `NSNull`, so text-only shares don't crash.

## Why

- No `url` → was wrongly treated as image → "Something went wrong".
- `https://` image URL → promise never resolved (hang).
- `https://` video/audio → promise resolved but share failed.
- `file` and `data` are the standard schemes for local/inline content ([RFC 8089](https://www.rfc-editor.org/rfc/rfc8089), [RFC 2397](https://datatracker.ietf.org/doc/html/rfc2397)), so we stick to those.

## How to test

**Before (without fix):**
- Share with no `url`, or with `url: "https://example.com/image.png"` → errors or hanging promise.

**After (with fix):**
- No `url` → only the message is sent.
- `https://` URL → message + link in text; promise resolves.
- Local path or `file://` or `data:` image → image share flow.

I ran the tests above locally, but any extra testing would be welcome.