### PR TITLE
fix(ios): open Instagram share flow on main thread

### DIFF
--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -127,25 +127,26 @@
         _mChangeRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
         placeholder = _mChangeRequest.placeholderForCreatedAsset;
     } completionHandler:^(BOOL success, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                NSURL *instagramURL = [NSURL URLWithString:[NSString stringWithFormat:@"instagram://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
 
-        if (success) {
-            NSURL *instagramURL = [NSURL URLWithString:[NSString stringWithFormat:@"instagram://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
-
-            if ([[UIApplication sharedApplication] canOpenURL:instagramURL]) {
-                if (@available(iOS 10.0, *)) {
-                    [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
-                }
-                if (resolve != NULL) {
-                    resolve(@[@true, @""]);
+                if ([[UIApplication sharedApplication] canOpenURL:instagramURL]) {
+                    if (@available(iOS 10.0, *)) {
+                        [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
+                    }
+                    if (resolve != NULL) {
+                        resolve(@[@true, @""]);
+                    }
                 }
             }
-        }
-        else {
-            //Error while writing
-            if (reject != NULL) {
-                reject(@"com.rnshare",@"error",error);
+            else {
+                //Error while writing
+                if (reject != NULL) {
+                    reject(@"com.rnshare",@"error",error);
+                }
             }
-        }
+        });
     }];
 }
 


### PR DESCRIPTION
- savePictureAndOpenInstagram currently opens the Instagram URL from the photo library completion handler.
- That callback may execute off the main thread, but UIApplication openURL should be triggered on the main thread.
- This change dispatches the success and error handling back to the main queue before opening Instagram or resolving/rejecting the promise.