### PR TITLE
fix(ios): populate missing linkMetadata values from URL fetch

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -77,6 +77,33 @@ const App = () => {
   };
 
   /**
+   * Share url with activityItemSources for custom link metadata
+   */
+  const shareUrlWithMetadata = async () => {
+    const url = 'https://github.com/react-native-share/react-native-share';
+    const shareOptions = {
+      url,
+      activityItemSources: [
+        {
+          placeholderItem: { type: 'url', content: url },
+          item: { default: { type: 'url', content: url } },
+          linkMetadata: { title: 'A Custom Share Title' }
+        }
+      ],
+      failOnCancel: false
+    };
+
+    try {
+      const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
+      setResult(JSON.stringify(ShareResponse, null, 2));
+    } catch (error) {
+      console.log('Error =>', error);
+      setResult('error: '.concat(getErrorString(error)));
+    }
+  };
+
+  /**
    * This functions share multiple images that
    * you send as the urls param
    */
@@ -401,6 +428,9 @@ const App = () => {
         </Text>
         <View style={styles.button}>
           <Button onPress={shareUrlWithMessage} title="Share Simple Url" />
+        </View>
+        <View style={styles.button}>
+          <Button onPress={shareUrlWithMetadata} title="Share Url with Metadata" />
         </View>
         <View style={styles.button}>
           <Button onPress={shareMultipleImages} title="Share Multiple Images" />

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -254,14 +254,9 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     }
 
     NSArray *activityItemSources = options[@"activityItemSources"];
-    if (activityItemSources) {
-        [activityItemSources enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-            RNShareActivityItemSource *activityItemSource = [[RNShareActivityItemSource alloc] initWithOptions:obj];
-            [items addObject:activityItemSource];
-        }];
-    }
+    BOOL hasActivityItemSources = activityItemSources != nil && activityItemSources.count > 0;
 
-    if (items.count == 0) {
+    if (items.count == 0 && !hasActivityItemSources) {
         RCTLogError(@"No `url` or `message` to share");
         return;
     }
@@ -290,67 +285,21 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
             [controller presentViewController:documentPicker animated:YES completion:nil];
             return;
         }
-    }    
-    
-    UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
-
-    BOOL disableOverlay = [RCTConvert BOOL:options[@"disableOverlay"]];
-    
-    if (@available(iOS 15.0, *)) {
-        if (disableOverlay == true) {
-                shareController.sheetPresentationController.largestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifierLarge;
-        }
-    }
-    
-    NSString *subject = [RCTConvert NSString:options[@"subject"]];
-    if (subject) {
-        [shareController setValue:subject forKey:@"subject"];
     }
 
-    NSArray *excludedActivityTypes = [RCTConvert NSStringArray:options[@"excludedActivityTypes"]];
-    if (excludedActivityTypes) {
-        shareController.excludedActivityTypes = excludedActivityTypes;
+    if (hasActivityItemSources) {
+        [self _fetchMetadataAndPresentShareController:items
+                                              options:options
+                                           controller:controller
+                                              resolve:resolve
+                                               reject:reject];
+    } else {
+        [self _presentShareController:items
+                              options:options
+                           controller:controller
+                              resolve:resolve
+                               reject:reject];
     }
-
-    __weak UIActivityViewController* weakShareController = shareController;
-    shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
-        
-        // always dismiss since this may be called from cancelled shares
-        // but the share menu would remain open, and our callback would fire again on close
-        if(weakShareController){
-            // closing activity view controller
-            [weakShareController dismissViewControllerAnimated:true completion:nil];
-        } else {
-            [controller dismissViewControllerAnimated:true completion:nil];
-        }
-
-        
-        if (activityError) {
-            reject(@"error",@"activityError",activityError);
-        } else {
-            resolve(@{
-                @"success": @(completed),
-                @"message": (RCTNullIfNil(activityType) ?: @"")
-            });
-        }
-        
-        // clear the completion handler to prevent cycles
-        if(weakShareController){
-            weakShareController.completionWithItemsHandler = nil;
-        }
-    };
-
-    shareController.modalPresentationStyle = UIModalPresentationPopover;
-    NSNumber *anchorViewTag = [RCTConvert NSNumber:options[@"anchor"]];
-    if (!anchorViewTag) {
-        shareController.popoverPresentationController.permittedArrowDirections = 0;
-    }
-    shareController.popoverPresentationController.sourceView = controller.view;
-    shareController.popoverPresentationController.sourceRect = [self sourceRectInView:controller.view anchorViewTag:anchorViewTag];
-
-    [controller presentViewController:shareController animated:YES completion:nil];
-
-    shareController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
 }
 
 
@@ -387,6 +336,100 @@ RCT_EXPORT_METHOD(isPackageInstalled:(NSString *)packagename
             @"message": @"com.apple.DocumentsApp"
         });
     }
+}
+
+#pragma mark - Share Controller
+
+- (void)_presentShareController:(NSArray *)items
+                        options:(NSDictionary *)options
+                     controller:(UIViewController *)controller
+                        resolve:(RCTPromiseResolveBlock)resolve
+                         reject:(RCTPromiseRejectBlock)reject
+{
+    UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
+
+    BOOL disableOverlay = [RCTConvert BOOL:options[@"disableOverlay"]];
+    if (@available(iOS 15.0, *)) {
+        if (disableOverlay == true) {
+            shareController.sheetPresentationController.largestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifierLarge;
+        }
+    }
+
+    NSString *subject = [RCTConvert NSString:options[@"subject"]];
+    if (subject) {
+        [shareController setValue:subject forKey:@"subject"];
+    }
+
+    NSArray *excludedActivityTypes = [RCTConvert NSStringArray:options[@"excludedActivityTypes"]];
+    if (excludedActivityTypes) {
+        shareController.excludedActivityTypes = excludedActivityTypes;
+    }
+
+    __weak UIActivityViewController* weakShareController = shareController;
+    shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
+        // always dismiss since this may be called from cancelled shares
+        // but the share menu would remain open, and our callback would fire again on close
+        if(weakShareController){
+            // closing activity view controller
+            [weakShareController dismissViewControllerAnimated:true completion:nil];
+        } else {
+            [controller dismissViewControllerAnimated:true completion:nil];
+        }
+
+        if (activityError) {
+            reject(@"error",@"activityError",activityError);
+        } else {
+            resolve(@{
+                @"success": @(completed),
+                @"message": (RCTNullIfNil(activityType) ?: @"")
+            });
+        }
+
+        // clear the completion handler to prevent cycles
+        if(weakShareController){
+            weakShareController.completionWithItemsHandler = nil;
+        }
+    };
+
+    shareController.modalPresentationStyle = UIModalPresentationPopover;
+    NSNumber *anchorViewTag = [RCTConvert NSNumber:options[@"anchor"]];
+    if (!anchorViewTag) {
+        shareController.popoverPresentationController.permittedArrowDirections = 0;
+    }
+    shareController.popoverPresentationController.sourceView = controller.view;
+    shareController.popoverPresentationController.sourceRect = [self sourceRectInView:controller.view
+                                                                        anchorViewTag:anchorViewTag];
+
+    [controller presentViewController:shareController animated:YES completion:nil];
+    shareController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
+}
+
+- (void)_fetchMetadataAndPresentShareController:(NSMutableArray *)items
+                                        options:(NSDictionary *)options
+                                     controller:(UIViewController *)controller
+                                        resolve:(RCTPromiseResolveBlock)resolve
+                                         reject:(RCTPromiseRejectBlock)reject
+{
+    NSArray *activityItemSources = options[@"activityItemSources"];
+    __block NSInteger pendingFetches = activityItemSources.count;
+    __weak RNShare *weakSelf = self;
+
+    [activityItemSources enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        RNShareActivityItemSource *activityItemSource = [[RNShareActivityItemSource alloc] initWithOptions:obj
+                                                                                                completion:^{
+            pendingFetches--;
+            if (pendingFetches == 0) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf _presentShareController:items
+                                              options:options
+                                           controller:controller
+                                              resolve:resolve
+                                               reject:reject];
+                });
+            }
+        }];
+        [items addObject:activityItemSource];
+    }];
 }
 
 # pragma mark - New Architecture

--- a/ios/RNShareActivityItemSource.h
+++ b/ios/RNShareActivityItemSource.h
@@ -5,7 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNShareActivityItemSource : NSObject<UIActivityItemSource>
 
-- (instancetype)initWithOptions:(NSDictionary *)options;
+- (instancetype)initWithOptions:(NSDictionary *)options
+                     completion:(void (^)(void))completion;
 
 @end
 

--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -16,14 +16,17 @@
     NSDictionary *subjectDictionary;
     NSDictionary *dataTypeIdentifierDictionary;
     NSDictionary *thumbnailImageDictionary;
+    void (^fetchCompletion)(void);
 #ifdef __IPHONE_13_0
     LPLinkMetadata *linkMetadata API_AVAILABLE(ios(13.0));
 #endif
 }
 
-- (instancetype)initWithOptions:(NSDictionary *)options {
+- (instancetype)initWithOptions:(NSDictionary *)options
+                     completion:(void (^)(void))completion {
     self = [super init];
     if (self) {
+        fetchCompletion = completion;
         placeholderItem = [RNShareActivityItemSource itemFromDictionary:options[@"placeholderItem"]];
 
 #ifdef __IPHONE_13_0
@@ -32,8 +35,14 @@
             if ([placeholderItem isKindOfClass:NSURL.class] && ![RNShareActivityItemSource isURLSchemeData:placeholderItem]) {
                 NSURL *URL = placeholderItem;
                 [self fetchMetadataForURL:URL];
+            } else {
+                [self _invokeAndClearCompletion];
             }
+        } else {
+            [self _invokeAndClearCompletion];
         }
+#else
+        [self _invokeAndClearCompletion];
 #endif
 
         itemDictionary = options[@"item"];
@@ -49,26 +58,38 @@
     if (@available(iOS 13.0, *)) {
         LPMetadataProvider *metadataProvider = [[LPMetadataProvider alloc] init];
         [metadataProvider startFetchingMetadataForURL:URL completionHandler:^(LPLinkMetadata * _Nullable metadata, NSError * _Nullable error) {
-            if (!self->linkMetadata) {
-                self->linkMetadata = metadata;
-            } else {
-                self->linkMetadata.originalURL = metadata.originalURL;
-                self->linkMetadata.URL = metadata.URL;
-                if(!self->linkMetadata.title) {
-                    self->linkMetadata.title = metadata.title;
-                }
-                self->linkMetadata.imageProvider = metadata.imageProvider;
-                if (self->linkMetadata.imageProvider) {
-                    self->linkMetadata.iconProvider = self->linkMetadata.imageProvider;
+            if (metadata) {
+                if (!self->linkMetadata) {
+                    self->linkMetadata = metadata;
                 } else {
-                    self->linkMetadata.iconProvider = metadata.iconProvider;
+                    self->linkMetadata.originalURL = metadata.originalURL;
+                    self->linkMetadata.URL = metadata.URL;
+                    if(!self->linkMetadata.title) {
+                        self->linkMetadata.title = metadata.title;
+                    }
+                    self->linkMetadata.imageProvider = metadata.imageProvider;
+                    if (self->linkMetadata.imageProvider) {
+                        self->linkMetadata.iconProvider = self->linkMetadata.imageProvider;
+                    } else {
+                        self->linkMetadata.iconProvider = metadata.iconProvider;
+                    }
+                    self->linkMetadata.remoteVideoURL = metadata.remoteVideoURL;
+                    self->linkMetadata.videoProvider = metadata.videoProvider;
                 }
-                self->linkMetadata.remoteVideoURL = metadata.remoteVideoURL;
-                self->linkMetadata.videoProvider = metadata.videoProvider;
             }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self _invokeAndClearCompletion];
+            });
         }];
     }
 #endif
+}
+
+- (void)_invokeAndClearCompletion {
+    if (fetchCompletion) {
+        fetchCompletion();
+        fetchCompletion = nil;
+    }
 }
 
 #pragma mark - Utilities
@@ -276,16 +297,7 @@
 - (nullable id)activityViewController:(nonnull UIActivityViewController *)activityViewController itemForActivityType:(nullable UIActivityType)activityType {
     if (itemDictionary) {
         NSDictionary *options = [RNShareActivityItemSource objectForActivityType:activityType inDictionary:itemDictionary];
-        id item = [RNShareActivityItemSource itemFromDictionary:options];
-
-        if (@available(iOS 13.0, *)) {
-            if ([item isKindOfClass:NSURL.class] && ![RNShareActivityItemSource isURLSchemeData:item]) {
-                NSURL *URL = item;
-                [self fetchMetadataForURL:URL];
-            }
-        }
-
-        return item;
+        return [RNShareActivityItemSource itemFromDictionary:options];
     }
     return nil;
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

- Defer UIActivityViewController initialization and presentation until the LPMetadataProvider fetch completes, so fetched values can fill in any missing fields in the custom linkMetadata before the delegate is called
- Remove fetchMetadataForURL calls from itemForActivityType which were triggering redundant concurrent fetches, once when UIActivityViewController was initialized and called the delegate, and again each time the user tapped an activity

Related to #1690 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested using `activityItemSources` with a custom `linkMetadata` title and a URL placeholder on an iOS simulator.

- Verified the share sheet presents with the custom title and the thumbnail fetched from the URL's metadata
- Verified `fetchMetadataForURL` is no longer called redundantly from `itemForActivityType`
- Verified `RNShareActivityItemSource` deallocates after the share sheet is dismissed with no leaked objects in the memory graph debugger

The following screenshots use the same `activityItemSources` options as the example included in this PR.

**Before** — original code: share sheet displays only the custom title with no thumbnail since the URL fetch completes after the delegate is called
<img width="402" height="874" alt="before" src="https://github.com/user-attachments/assets/9c7e7255-4db3-40f5-92c8-7ea113a1d66c" />

**After** — with fix: share sheet displays both the custom title and the thumbnail fetched from the URL metadata since presentation is deferred until the fetch completes
<img width="402" height="874" alt="after" src="https://github.com/user-attachments/assets/a082572c-2b09-4647-9af4-457d5e2a31af" />



